### PR TITLE
Add site theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Welcome to my personal portfolio repository. This portfolio showcases my skills,
 - CSS
 - JavaScript
 
+## Features
+
+- Dark mode toggle with theme persistence
+
 ## Setup and Run
 
 1. Clone this repository.

--- a/finance_app.html
+++ b/finance_app.html
@@ -31,9 +31,18 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 
     <script>
-         $(document).ready(function() {
-            $("#headerInclude").load("header.html");
+        $(document).ready(function() {
+            $("#headerInclude").load("header.html", function() {
+                const toggle = $("#darkModeToggle");
+                toggle.on("click", function() {
+                    $("body").toggleClass("light-mode");
+                    localStorage.setItem("theme", $("body").hasClass("light-mode") ? "light" : "dark");
+                });
+            });
             $("#footerInclude").load("footer.html");
+            if (localStorage.getItem("theme") === "light") {
+                $("body").addClass("light-mode");
+            }
         });
     </script>
 </body>

--- a/header.html
+++ b/header.html
@@ -23,6 +23,9 @@
                 <li class="nav-item">
                     <a class="nav-link" href="https://www.linkedin.com/in/stephen-wilkinson-381784144/" rel="noopener noreferrer" target="_blank"><i class="fab fa-linkedin"></i> LinkedIn</a>
                 </li>
+                <li class="nav-item">
+                    <button id="darkModeToggle" class="btn btn-secondary btn-sm ml-2">Toggle Theme</button>
+                </li>
             </ul>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -72,8 +72,17 @@
 
     <script>
         $(document).ready(function() {
-            $("#headerInclude").load("header.html");
+            $("#headerInclude").load("header.html", function() {
+                const toggle = $("#darkModeToggle");
+                toggle.on("click", function() {
+                    $("body").toggleClass("light-mode");
+                    localStorage.setItem("theme", $("body").hasClass("light-mode") ? "light" : "dark");
+                });
+            });
             $("#footerInclude").load("footer.html");
+            if (localStorage.getItem("theme") === "light") {
+                $("body").addClass("light-mode");
+            }
         });
     </script>
 </body>

--- a/recipe_app.html
+++ b/recipe_app.html
@@ -28,9 +28,18 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 
     <script>
-         $(document).ready(function() {
-            $("#headerInclude").load("header.html");
+        $(document).ready(function() {
+            $("#headerInclude").load("header.html", function() {
+                const toggle = $("#darkModeToggle");
+                toggle.on("click", function() {
+                    $("body").toggleClass("light-mode");
+                    localStorage.setItem("theme", $("body").hasClass("light-mode") ? "light" : "dark");
+                });
+            });
             $("#footerInclude").load("footer.html");
+            if (localStorage.getItem("theme") === "light") {
+                $("body").addClass("light-mode");
+            }
 
             $("button").click(function() {
                 var query = $("input").val();

--- a/styles.css
+++ b/styles.css
@@ -91,3 +91,26 @@ h1, h2, h3, h4, h5, h6 {
 .back-to-top:hover {
     color: #5D737E;
 }
+
+/* Light mode styles */
+body.light-mode {
+    background-color: #F4F4F9;
+    color: #1E2022;
+}
+
+body.light-mode .navbar,
+body.light-mode .footer {
+    background-color: #e9ecef;
+}
+
+body.light-mode .navbar .nav-link,
+body.light-mode .footer-nav li a,
+body.light-mode .back-to-top {
+    color: #1E2022 !important;
+}
+
+body.light-mode .navbar .nav-link:hover,
+body.light-mode .footer-nav li a:hover,
+body.light-mode .back-to-top:hover {
+    color: #5D737E !important;
+}

--- a/todo_app.html
+++ b/todo_app.html
@@ -29,9 +29,18 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 
     <script>
-         $(document).ready(function() {
-            $("#headerInclude").load("header.html");
+        $(document).ready(function() {
+            $("#headerInclude").load("header.html", function() {
+                const toggle = $("#darkModeToggle");
+                toggle.on("click", function() {
+                    $("body").toggleClass("light-mode");
+                    localStorage.setItem("theme", $("body").hasClass("light-mode") ? "light" : "dark");
+                });
+            });
             $("#footerInclude").load("footer.html");
+            if (localStorage.getItem("theme") === "light") {
+                $("body").addClass("light-mode");
+            }
         });
     </script>
 </body>

--- a/weather_app.html
+++ b/weather_app.html
@@ -32,8 +32,17 @@
 
     <script>
         $(document).ready(function() {
-            $("#headerInclude").load("header.html");
+            $("#headerInclude").load("header.html", function() {
+                const toggle = $("#darkModeToggle");
+                toggle.on("click", function() {
+                    $("body").toggleClass("light-mode");
+                    localStorage.setItem("theme", $("body").hasClass("light-mode") ? "light" : "dark");
+                });
+            });
             $("#footerInclude").load("footer.html");
+            if (localStorage.getItem("theme") === "light") {
+                $("body").addClass("light-mode");
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add dark/light theme toggle to header
- persist theme with localStorage and apply in all pages
- update styling for light mode
- document new feature

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68405f62c73c83208dbba769e618c74e