### PR TITLE
Add functional todo list page

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -148,3 +148,25 @@ body.light-mode .footer-nav li a:hover,
 body.light-mode .back-to-top:hover {
     color: #5D737E !important;
 }
+/* Todo App styles */
+.todo-input {
+    max-width: 300px;
+    margin-right: 5px;
+}
+.todo-list {
+    list-style-type: none;
+    padding-left: 0;
+}
+.todo-item {
+    display: flex;
+    align-items: center;
+    margin-bottom: 8px;
+}
+.todo-item.completed span {
+    text-decoration: line-through;
+    opacity: 0.6;
+}
+.todo-item button {
+    margin-left: 8px;
+}
+

--- a/todo_app.html
+++ b/todo_app.html
@@ -17,9 +17,11 @@
     <!-- Todo App main content -->
     <main class="container mt-5">
         <h2>Todo App</h2>
-        <input type="text" placeholder="Enter task">
-        <button>Add Task</button>
-        <ul>
+        <div class="form-inline mb-3">
+            <input type="text" class="form-control todo-input" placeholder="Enter task">
+            <button class="btn btn-primary ml-2 add-task">Add Task</button>
+        </div>
+        <ul class="todo-list">
             <!-- Todo list items will appear here -->
         </ul>
     </main>
@@ -41,6 +43,62 @@
             if (localStorage.getItem("theme") === "light") {
                 $("body").addClass("light-mode");
             }
+
+            const input = $(".todo-input");
+            const list = $(".todo-list");
+
+            function saveTasks() {
+                const tasks = [];
+                list.find("li").each(function() {
+                    tasks.push({
+                        text: $(this).find("span").text(),
+                        completed: $(this).hasClass("completed")
+                    });
+                });
+                localStorage.setItem("todoTasks", JSON.stringify(tasks));
+            }
+
+            function addTask(text, completed) {
+                const li = $("<li class='todo-item'></li>");
+                const span = $("<span></span>").text(text);
+                const completeBtn = $("<button class='btn btn-success btn-sm'>Done</button>");
+                const deleteBtn = $("<button class='btn btn-danger btn-sm'>Delete</button>");
+                li.append(span, completeBtn, deleteBtn);
+                if (completed) li.addClass("completed");
+                list.append(li);
+            }
+
+            $(".add-task").on("click", function() {
+                const task = input.val().trim();
+                if (task) {
+                    addTask(task, false);
+                    input.val("");
+                    saveTasks();
+                }
+            });
+
+            input.on("keypress", function(e) {
+                if (e.which === 13) {
+                    $(".add-task").click();
+                }
+            });
+
+            list.on("click", ".btn-success", function() {
+                $(this).closest("li").toggleClass("completed");
+                saveTasks();
+            });
+
+            list.on("click", ".btn-danger", function() {
+                $(this).closest("li").remove();
+                saveTasks();
+            });
+
+            (function loadTasks() {
+                const stored = localStorage.getItem("todoTasks");
+                if (stored) {
+                    JSON.parse(stored).forEach(t => addTask(t.text, t.completed));
+                }
+            })();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- make `todo_app.html` interactive by adding add/delete/complete logic with localStorage persistence
- add new styles for todo list elements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406f61811c832084f6fedca70e61ea