### PR TITLE
Add interactive finance home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ Welcome to my personal portfolio repository. This portfolio showcases my skills,
  - Floating light/dark theme toggle with persistence
 - Accessible "Skip to Content" link
 - Animated navigation bar that appears on scroll
-- Finance app with stock price lookup powered by the Alpha Vantage API, year-to-date charts, and recent ticker history
+ - Finance app with stock price lookup powered by the Alpha Vantage API, year-to-date charts, and recent ticker history
+ - Finance home screen showcasing market overview panels, heat maps, news ticker, and economic calendars
 
 ## Setup and Run
 
 1. Clone this repository.
 2. Open `index.html` in your preferred browser.
-3. For stock price lookup, open `finance_app.html`, enter a ticker symbol, and view the year-to-date chart. Recent searches are saved for convenience.
+3. Open `finance_home.html` to explore market data, news, and calendars in one dashboard.
+4. For stock price lookup, open `finance_app.html`, enter a ticker symbol, and view the year-to-date chart. Recent searches are saved for convenience.

--- a/finance_home.html
+++ b/finance_home.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Finance Home - Stephen Wilkinson's Portfolio</title>
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet">
+    <link href='https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;700&display=swap' rel='stylesheet'>
+    <script src="https://kit.fontawesome.com/a076d05399.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        .market-panel {
+            background-color: #2B2C2F;
+            border-radius: 8px;
+            padding: 15px;
+            margin-bottom: 20px;
+        }
+        body.light-mode .market-panel {
+            background-color: #ffffff;
+        }
+        .heatmap {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+            gap: 5px;
+        }
+        .heatmap div {
+            padding: 20px;
+            text-align: center;
+            color: #fff;
+            cursor: pointer;
+        }
+        .news-ticker {
+            background-color: #232526;
+            padding: 10px;
+            color: #F4F4F9;
+            overflow: hidden;
+            white-space: nowrap;
+        }
+        .news-item {
+            display: inline-block;
+            padding-right: 50px;
+            animation: ticker 20s linear infinite;
+        }
+        @keyframes ticker {
+            from { transform: translateX(100%); }
+            to { transform: translateX(-100%); }
+        }
+        .suggestions {
+            position: absolute;
+            background: #2B2C2F;
+            width: 100%;
+            z-index: 1050;
+        }
+        .suggestions div {
+            padding: 5px 10px;
+            cursor: pointer;
+        }
+        .suggestions div:hover {
+            background: #5D737E;
+        }
+        body.light-mode .suggestions {
+            background: #ffffff;
+        }
+    </style>
+</head>
+<body>
+<a id="top"></a>
+<div id="headerInclude"></div>
+<main class="container mt-4">
+    <div class="position-relative mb-3">
+        <input id="searchInput" type="text" class="form-control" placeholder="Search ticker">
+        <div id="suggestions" class="suggestions d-none"></div>
+    </div>
+    <div id="marketOverview" class="row"></div>
+    <div class="row">
+        <div class="col-md-6">
+            <h4>Top Gainers</h4>
+            <ul id="gainers" class="list-unstyled"></ul>
+        </div>
+        <div class="col-md-6">
+            <h4>Top Losers</h4>
+            <ul id="losers" class="list-unstyled"></ul>
+        </div>
+    </div>
+    <h4 class="mt-4">Market Heat Map</h4>
+    <div id="heatMap" class="heatmap mb-4"></div>
+    <h4>Major News</h4>
+    <div id="newsTicker" class="news-ticker mb-4"></div>
+    <h4>Signal Alerts</h4>
+    <ul id="signals" class="list-unstyled"></ul>
+    <h4 class="mt-4">Economic Calendar</h4>
+    <table id="econCalendar" class="table table-sm table-striped"></table>
+    <h4 class="mt-4">Earnings Calendar</h4>
+    <table id="earningsCalendar" class="table table-sm table-striped"></table>
+</main>
+<div id="footerInclude"></div>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js"></script>
+<script>
+$(document).ready(function(){
+    $("#headerInclude").load("header.html", function() {
+        const toggle = $("#darkModeToggle");
+        function updateToggleText() {
+            toggle.text($("body").hasClass("light-mode") ? "Dark Mode" : "Light Mode");
+        }
+        toggle.on("click", function() {
+            $("body").toggleClass("light-mode");
+            localStorage.setItem("theme", $("body").hasClass("light-mode") ? "light" : "dark");
+            updateToggleText();
+        });
+        updateToggleText();
+    });
+    $("#footerInclude").load("footer.html");
+    if (localStorage.getItem("theme") === "light") { $("body").addClass("light-mode"); }
+
+    const indices = [
+        { name: 'DOW', symbol: 'DJI' },
+        { name: 'NASDAQ', symbol: 'IXIC' },
+        { name: 'S&P 500', symbol: 'GSPC' },
+        { name: 'RUSSELL 2000', symbol: 'RUT' }
+    ];
+
+    const samplePrice = () => 30000 + Math.random() * 1000;
+    const sampleChange = () => (Math.random() - 0.5) * 2;
+    const generateSeries = () => {
+        const data = [];
+        for(let i=0;i<30;i++) data.push(samplePrice() + sampleChange()*50);
+        return data;
+    };
+
+    const renderMarket = () => {
+        $('#marketOverview').empty();
+        indices.forEach(idx => {
+            const price = samplePrice();
+            const change = sampleChange();
+            const color = change >=0 ? 'text-success' : 'text-danger';
+            const card = $(
+                `<div class='col-md-6 col-lg-3'><div class='market-panel'>
+                    <h5>${idx.name}</h5>
+                    <p>$${price.toFixed(2)} <span class='${color}'>(${change.toFixed(2)}%)</span></p>
+                    <canvas id='chart-${idx.symbol}' height='80'></canvas>
+                </div></div>`);
+            $('#marketOverview').append(card);
+            new Chart(card.find('canvas'), {
+                type: 'line',
+                data: { labels: Array.from({length:30},(_,i)=>i+1), datasets:[{ data: generateSeries(), borderColor: '#5D737E', fill:false, tension:0.3 }] },
+                options: {responsive:true, plugins:{legend:{display:false}}, scales:{x:{display:false},y:{display:false}}}
+            });
+        });
+    };
+
+    const stocks = ['AAPL','MSFT','GOOGL','AMZN','TSLA','META','BRK.A','JPM'];
+    const getRandomStocks = () => stocks.sort(()=>0.5-Math.random()).slice(0,3).map(s=>`${s} ${(Math.random()*10).toFixed(2)}%`);
+
+    const renderLists = () => {
+        const gainers = getRandomStocks();
+        const losers = getRandomStocks();
+        $('#gainers').html(gainers.map(g=>`<li class='text-success'>${g}</li>`));
+        $('#losers').html(losers.map(l=>`<li class='text-danger'>${l}</li>`));
+    };
+
+    const heatSectors = ['Technology','Financial','Healthcare','Consumer Cyclical','Energy','Utilities'];
+    const renderHeatmap = () => {
+        $('#heatMap').empty();
+        heatSectors.forEach(sec => {
+            const perf = (Math.random()-0.5)*4;
+            const color = perf>0 ? `rgba(40,167,69,${Math.min(1,perf/4+0.3)})` : `rgba(220,53,69,${Math.min(1,-perf/4+0.3)})`;
+            const div = $(`<div style='background:${color}' title='${sec}: ${perf.toFixed(2)}%'>${sec}</div>`);
+            $('#heatMap').append(div);
+        });
+    };
+
+    const headlines = [
+        'Stocks edge higher amid earnings reports',
+        'Federal Reserve signals rate pause',
+        'Oil prices fall on demand concerns',
+        'Tech sector leads market gains'
+    ];
+    const renderNews = () => {
+        const html = headlines.map(h=>`<span class='news-item'>${new Date().toLocaleTimeString()} - ${h}</span>`).join('');
+        $('#newsTicker').html(html);
+    };
+
+    const signals = [ 'AAPL breaks resistance', 'TSLA forms double top', 'AMZN hits new high', 'MSFT approaching support' ];
+    $('#signals').html(signals.map(s=>`<li>${s}</li>`));
+
+    const econ = [
+        { date:'2024-06-01', event:'Nonfarm Payrolls', impact:'High', actual:'250K', expected:'200K', previous:'220K' },
+        { date:'2024-06-03', event:'ISM Manufacturing', impact:'Medium', actual:'52', expected:'51', previous:'50' }
+    ];
+    const renderTable = (tbl, data) => {
+        const header = Object.keys(data[0]);
+        const th = '<tr>' + header.map(h=>`<th>${h}</th>`).join('') + '</tr>';
+        const rows = data.map(d=> '<tr>'+ header.map(h=>`<td>${d[h]}</td>`).join('') + '</tr>').join('');
+        tbl.html(th+rows);
+    };
+    renderTable($('#econCalendar'), econ);
+
+    const earnings = [
+        { date:'2024-06-02', ticker:'AAPL', est:'$1.20', importance:'High' },
+        { date:'2024-06-04', ticker:'MSFT', est:'$2.30', importance:'Medium' }
+    ];
+    renderTable($('#earningsCalendar'), earnings);
+
+    const allTickers = stocks;
+    $('#searchInput').on('input', function(){
+        const val = this.value.toUpperCase();
+        if(!val){ $('#suggestions').addClass('d-none'); return; }
+        const list = allTickers.filter(t=>t.startsWith(val)).slice(0,5);
+        if(list.length){
+            $('#suggestions').html(list.map(t=>`<div>${t}</div>`)).removeClass('d-none');
+        } else { $('#suggestions').addClass('d-none'); }
+    });
+    $('#suggestions').on('click','div',function(){
+        $('#searchInput').val($(this).text());
+        $('#suggestions').addClass('d-none');
+    });
+
+    renderMarket();
+    renderLists();
+    renderHeatmap();
+    renderNews();
+    setInterval(()=>{ renderMarket(); renderLists(); renderHeatmap(); }, 60000);
+});
+</script>
+</body>
+</html>

--- a/header.html
+++ b/header.html
@@ -16,6 +16,7 @@
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                         <a class="dropdown-item" href="weather_app.html">Weather App</a>
                         <a class="dropdown-item" href="finance_app.html">Finance App</a>
+                        <a class="dropdown-item" href="finance_home.html">Finance Home</a>
                         <a class="dropdown-item" href="todo_app.html">Todo List App</a>
                         <a class="dropdown-item" href="recipe_app.html">Recipe Finder App</a>
                     </div>


### PR DESCRIPTION
## Summary
- create `finance_home.html` with market overview, heat map, news ticker and calendars
- link new page from header dropdown
- document dashboard in README

## Testing
- `tidy -q finance_home.html 2>&1 | head`

------
https://chatgpt.com/codex/tasks/task_e_684188ffb5b48320b9cd0f666ddb3d56