### PR TITLE
Add default weather data on load

### DIFF
--- a/weather_app.html
+++ b/weather_app.html
@@ -58,8 +58,7 @@
                 $("#weatherDetails").html(`<p>${msg}</p>`);
             }
 
-            $("#getWeatherBtn").on("click", function() {
-                const zip = $("#zipInput").val().trim();
+            function fetchWeather(zip) {
                 if (!zip) {
                     showMessage("Please enter a ZIP code.");
                     return;
@@ -90,7 +89,16 @@
                             .fail(function() { showMessage("Error fetching weather data."); });
                     })
                     .fail(function() { showMessage("Error fetching location data."); });
+            }
+
+            $("#getWeatherBtn").on("click", function() {
+                const zip = $("#zipInput").val().trim();
+                fetchWeather(zip);
             });
+
+            const defaultZip = "10001";
+            $("#zipInput").val(defaultZip);
+            fetchWeather(defaultZip);
 
             $("#zipInput").on("keypress", function(e) {
                 if (e.which === 13) {


### PR DESCRIPTION
## Summary
- add `fetchWeather` helper in weather app
- load default weather for ZIP code 10001 when the page opens

## Testing
- `htmlhint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e8cdc6288320b61fa07b0f3f0747