### PR TITLE
Fix nav dropdown in finance_app

### DIFF
--- a/finance_app.html
+++ b/finance_app.html
@@ -102,6 +102,7 @@
     <table id="earningsCalendar" class="table table-sm table-striped"></table>
 </main>
 <div id="footerInclude"></div>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js"></script>
 <script>
   // ───────────────────────────────────────────────────
   // Replace "YOUR_API_KEY" with your actual Finnhub.io API key. When the


### PR DESCRIPTION
## Summary
- enable Bootstrap JS on finance_app page so nav dropdown works

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842f921f82c8320ac0eb61e95cc65c9