### PR TITLE
Replace Sub360 internship with Front-End Freelance Developer

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,14 +137,14 @@
         <h2>Experience</h2>
         <div class="timeline">
           <article class="card timeline-item">
-            <h3>React Software Development Intern &mdash; Sub360</h3>
-            <p class="meta">February 2023 &ndash; August 2023 &middot; Remote</p>
+            <h3>Front-End Freelance Developer</h3>
+            <p class="meta">August 2023 to Present</p>
             <ul>
-              <li>Built and debugged React components in a shared codebase, using Git and GitHub for branching, commits, and pull requests in a team workflow.</li>
-              <li>Investigated and resolved front-end issues through browser dev tools, isolated testing, and iterative debugging cycles.</li>
-              <li>Documented component behavior and implementation details, improving team knowledge handoff and reducing onboarding friction.</li>
+              <li>Build and refine responsive portfolio, landing page, and small business website concepts.</li>
+              <li>Use HTML, CSS, JavaScript, and React to create clean UI drafts and interactive prototypes.</li>
+              <li>Communicate project scope, document updates, and translate client goals into practical front-end tasks.</li>
             </ul>
-            <div class="tag-row"><span class="tag">React</span><span class="tag">JavaScript</span><span class="tag">Git</span><span class="tag">Remote</span></div>
+            <div class="tag-row"><span class="tag">HTML</span><span class="tag">CSS</span><span class="tag">JavaScript</span><span class="tag">React</span></div>
           </article>
           <article class="card timeline-item">
             <h3>Cook and Cashier &mdash; Samson&rsquo;s Concessions</h3>


### PR DESCRIPTION
### Motivation
- Update the Experience section of the portfolio to remove the Sub360 internship and surface the current freelance front-end role instead.

### Description
- Edited `index.html` to replace the "React Software Development Intern — Sub360" entry with a `Front-End Freelance Developer` entry (dates set to `August 2023 to Present`), updated the three responsibility bullets to reflect responsive portfolio/landing-page work, HTML/CSS/JavaScript/React prototyping, and client communication, and changed the tag row to `HTML`, `CSS`, `JavaScript`, and `React`.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb47250e588320b42c69e5defde72e)