### PR TITLE
Remove internship bullet and About photo from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,6 @@
           <ul>
             <li>CompTIA A+ &amp; Network+ certified &mdash; Security+ in progress</li>
             <li>Hands-on home labs: VLANs, DNS/DHCP, NAS, Docker, Pi</li>
-            <li>React internship experience &amp; front-end development</li>
             <li>Patient communication and customer service track record</li>
           </ul>
         </aside>
@@ -87,10 +86,6 @@
           <p>I earned a BS in Digital Media Arts from Canisius College in 2016 and am currently pursuing cybersecurity coursework at Eastern Florida State College. I hold CompTIA A+ and Network+ and am actively studying for Security+. I am especially motivated by resolving user issues cleanly, documenting solutions clearly, and building dependable support habits.</p>
           <p class="availability-note">&#128197; Available immediately &middot; On-site (Palm Bay, FL area) or fully remote</p>
         </div>
-        <figure class="profile-card">
-          <img src="images/headshot.jpg" alt="Portrait of Stephen Wilkinson" loading="lazy" width="320" height="320">
-          <figcaption>Hands-on learner with a service-first approach to IT support and troubleshooting.</figcaption>
-        </figure>
       </div>
     </section>
 


### PR DESCRIPTION
### Motivation
- Update the homepage content and layout by removing an internship mention and the profile photo to match requested wording and presentation.

### Description
- Deleted the "React internship experience & front-end development" list item from the "What I Bring" hero panel in `index.html`.
- Removed the `<figure class="profile-card">` block (profile photo and figcaption) from the About section in `index.html`.

### Testing
- No automated tests were run because this is a content-only HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8bcaff04832082040fa4224f1f63)