### PR TITLE
Update resume with newly earned networking skills

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -1,1 +1,49 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Stephen Wilkinson Resume</title></head><body><p>Stephen Wilkinson Resume download placeholder. Please replace this file with your latest PDF resume when ready.</p></body></html>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Stephen Wilkinson Resume</title>
+</head>
+<body>
+  <h1>Stephen Wilkinson</h1>
+  <h2>Networking Skills</h2>
+  <p>Added from competency certificate in networking.</p>
+
+  <h3>Network Hardware</h3>
+  <ul>
+    <li>Implement components and cabling solutions</li>
+    <li>Implement wired and wireless devices</li>
+  </ul>
+
+  <h3>Network Configuration</h3>
+  <ul>
+    <li>Configure IP addressing</li>
+    <li>Configure routers and switches</li>
+    <li>Configure wireless and VoIP</li>
+  </ul>
+
+  <h3>Network Management</h3>
+  <ul>
+    <li>Manage DHCP services</li>
+    <li>Manage DNS services</li>
+    <li>Manage device discovery and VLANs</li>
+    <li>Manage logs</li>
+  </ul>
+
+  <h3>Network Security</h3>
+  <ul>
+    <li>Secure firewalls and security appliances</li>
+    <li>Secure switches and wireless networks</li>
+    <li>Secure services and passwords</li>
+    <li>Secure remote connections and VPNs</li>
+    <li>Secure network exploits</li>
+  </ul>
+
+  <h3>Network Troubleshooting</h3>
+  <ul>
+    <li>Troubleshoot configuration and services</li>
+    <li>Troubleshoot wired and wireless connectivity</li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Replace the placeholder resume download page with a concrete networking skills section derived from a recently earned competency certificate.
- Provide a readable HTML resume page that lists tangible networking abilities for recruiters or automated site use.

### Description
- Replaced `resume.html` placeholder with structured HTML containing headings and five skill categories: Network Hardware, Network Configuration, Network Management, Network Security, and Network Troubleshooting.
- Added concise bullet points under each category covering tasks such as implementing cabling and devices, configuring IPs/routers/switches/wireless/VoIP, managing DHCP/DNS/VLANs and logs, securing firewalls/switches/VPNs/services, and troubleshooting connectivity and configurations.

### Testing
- Verified the updated file exists and inspected `resume.html` content with `rg` and `sed` to confirm the new sections were added.
- Confirmed the content changes by checking the file diff and viewing the file with a line-numbered listing using `nl` to ensure the expected lines are present.
- All verification commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc00a76dc8320883fb9abc0212697)