### PR TITLE
Refine hero card into IT Support Snapshot

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,39 @@
         <div class="badge-row"><span class="badge earned">CompTIA A+ · Completed</span><span class="badge progress">CompTIA Network+ · In Progress</span><span class="badge planned">CompTIA Security+ · Planned</span><span class="badge neutral">Help Desk Ready</span><span class="badge neutral">Cybersecurity Student</span></div>
         <div class="cta-row"><a class="button primary" href="#contact">Contact Me</a><a class="button accent" href="resume.html" download>Download Resume</a><a class="button ghost" href="#projects">View Projects &amp; Labs</a></div>
       </article>
-      <aside class="hero-panel"><h2>Current Focus</h2><p>I am focused on entry-level IT support work, with an emphasis on troubleshooting, clear communication, and steady hands-on practice.</p><p>My current direction is help desk or desktop support. I am building from A+ fundamentals, continuing Network+ study, and documenting practical lab work as I improve.</p></aside>
+      <aside class="hero-panel snapshot" aria-labelledby="snapshot-title">
+        <h2 id="snapshot-title">IT Support Snapshot</h2>
+
+        <section class="snapshot-section" aria-labelledby="ready-now">
+          <h3 id="ready-now">Ready Now</h3>
+          <ul>
+            <li>Windows 10/11 troubleshooting</li>
+            <li>User account and password support</li>
+            <li>Software installs and updates</li>
+            <li>DNS, DHCP, Wi-Fi basics</li>
+            <li>Printer and peripheral support</li>
+          </ul>
+        </section>
+
+        <section class="snapshot-section" aria-labelledby="in-progress">
+          <h3 id="in-progress">In Progress</h3>
+          <ul>
+            <li>Network+ study</li>
+            <li>Home lab documentation</li>
+            <li>Ticket-style troubleshooting notes</li>
+            <li>Security+ foundation after Network+</li>
+          </ul>
+        </section>
+
+        <section class="snapshot-section" aria-labelledby="work-style">
+          <h3 id="work-style">Work Style</h3>
+          <ul>
+            <li>Clear communication</li>
+            <li>Methodical troubleshooting</li>
+            <li>Reliable follow-through</li>
+          </ul>
+        </section>
+      </aside>
     </div>
   </section>
 

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,13 @@ a{color:var(--brand)}a:focus-visible,button:focus-visible{outline:3px solid var(
 .hero{padding-top:5.5rem}.hero-grid{display:grid;grid-template-columns:1.4fr .8fr;gap:1.25rem;align-items:start}
 .hero-panel,.card,.contact,.tile{background:var(--panel);border:1px solid var(--line);border-radius:14px}
 .hero-panel{padding:1rem 1.05rem;align-self:start}.kicker{color:#9cc9ff;margin:0 0 .5rem;font-weight:600}.subhead{font-weight:600;color:#d7e7ff}.lead{max-width:72ch}
+.snapshot{padding:1rem 1.05rem;display:grid;gap:.8rem}
+.snapshot h2{margin:0;font-size:1.25rem}
+.snapshot-section{border-top:1px solid var(--line);padding-top:.65rem}
+.snapshot-section:first-of-type{border-top:0;padding-top:.2rem}
+.snapshot-section h3{margin:0 0 .35rem;font-size:.8rem;letter-spacing:.06em;text-transform:uppercase;color:#a9bddf}
+.snapshot-section ul{margin:0;padding-left:1rem;display:grid;gap:.15rem}
+.snapshot-section li{line-height:1.35;color:#dce8ff}
 h1{font-size:clamp(2rem,3.2vw,3.2rem);line-height:1.15;margin:.25rem 0 .4rem}h2{font-size:clamp(1.5rem,2.2vw,2rem);margin:0 0 .8rem}
 .badge-row{display:flex;flex-wrap:wrap;gap:.5rem;margin:1rem 0}.badge{padding:.33rem .7rem;border-radius:999px;font-size:.82rem;font-weight:600}.earned{background:#193927;color:#9af3bc}.progress{background:#29375d;color:#b7d4ff}.planned{background:#3b2e1f;color:#ffd49d}.neutral{background:#22314d;color:#dce9ff}
 .cta-row{display:flex;flex-wrap:wrap;gap:.65rem;margin-top:1rem}.button{padding:.72rem 1rem;border-radius:10px;text-decoration:none;font-weight:600;border:1px solid transparent}.primary{background:var(--brand);color:#071427}.accent{background:var(--brand-2);color:#062116}.ghost{background:transparent;border-color:var(--line);color:var(--text)}


### PR DESCRIPTION
### Motivation
- Replace the paragraph-heavy "Current Focus" hero aside with a compact, professional, scannable "IT Support Snapshot" dashboard that highlights help-desk readiness. 
- Meet design constraints to keep the card on the right side on desktop, preserve the dark theme and border style, use left-aligned headings and compact lists, and ensure clean stacking on mobile. 

### Description
- Replaced the original aside in `index.html` with a semantic `aside` containing three sections: `Ready Now`, `In Progress`, and `Work Style`, each using left-aligned headings and compact unordered lists. 
- Added focused styles in `styles.css` for `.snapshot` and `.snapshot-section` (subtle dividers, compact spacing, small uppercase labels, and color tuned for the existing dark theme). 
- Preserved the existing `.hero-grid` layout and media query breakpoints so the card remains right-aligned on desktop and stacks responsively on smaller screens. 
- Modified files: `index.html` and `styles.css`.

### Testing
- Ran `git diff -- index.html styles.css` to review the changes and confirmed the updated aside and new CSS rules appeared in the diff. 
- Committed the change with `git commit -m "Refine hero card into IT Support Snapshot dashboard"` which succeeded. 
- Verified the commit hash with `git rev-parse --short HEAD` and inspected file regions (`nl -ba`) to confirm the snapshot markup and stylesheet additions, and confirmed media query breakpoints were unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdccd4ca608320a77ec1950b57a683)