### PR TITLE
Clarify certification status and refresh hero/certification copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Stephen Wilkinson | IT Support Candidate | CompTIA A+ Certified</title>
-  <meta name="description" content="Resume portfolio for Stephen Wilkinson, an entry-level IT support candidate and cybersecurity student with CompTIA A+ completed, Network+ in progress, and hands-on help desk, networking, and home lab experience.">
+  <title>Stephen Wilkinson | Entry-Level IT Support Candidate</title>
+  <meta name="description" content="Resume portfolio for Stephen Wilkinson, an entry-level IT support candidate and cybersecurity student with CompTIA A+ in progress and hands-on help desk, networking, and home lab experience.">
   <meta property="og:title" content="Stephen Wilkinson | Entry-Level IT Support Candidate">
-  <meta property="og:description" content="CompTIA A+ completed, Network+ in progress, Security+ planned. Entry-level IT support candidate building through hands-on labs and home troubleshooting.">
+  <meta property="og:description" content="CompTIA A+ in progress. Entry-level IT support candidate building through hands-on labs and home troubleshooting.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://wilkins4.github.io/">
   <meta name="theme-color" content="#0b1220">
@@ -31,9 +31,11 @@
     <div class="container hero-grid">
       <article>
         <p class="kicker">Palm Bay, FL | Open to Remote, Hybrid, and On-Site Roles | Available Now</p>
-        <h1>Stephen Wilkinson<br><span>IT Support Technician · Palm Bay, FL</span></h1>
-                <p class="lead">I am pursuing entry-level help desk and IT support roles with hands-on practice in Windows support, basic networking, troubleshooting, documentation, and customer-facing problem solving.</p>
-        <div class="badge-row"><span class="badge earned">CompTIA A+ • Completed</span><span class="badge progress">Network+ • In Progress</span><span class="badge planned">Security+ • Planned</span><span class="badge neutral">Help Desk Ready</span><span class="badge neutral">Cybersecurity Student</span></div>
+        <h1>Entry-Level IT Support Candidate</h1>
+        <p class="meta">Stephen Wilkinson · Palm Bay, FL</p>
+                <p class="lead">I am currently studying for CompTIA A+ and building toward an entry-level help desk or IT support role where I can apply Windows troubleshooting, customer service, documentation, and basic networking skills.</p>
+        <div class="badge-row"><span class="badge progress">CompTIA A+ In Progress</span><span class="badge neutral">Help Desk Ready</span><span class="badge neutral">Cybersecurity Student</span></div>
+        <p class="section-intro">CompTIA A+ In Progress</p>
         <div class="cta-row"><a class="button primary" href="#contact">Contact Me</a><a class="button accent" href="resume.html" download>Download Resume</a><a class="button ghost" href="#projects">View Projects &amp; Labs</a></div>
       </article>
       <aside class="hero-panel snapshot" aria-labelledby="snapshot-title">
@@ -53,10 +55,10 @@
         <section class="snapshot-section" aria-labelledby="in-progress">
           <h3 id="in-progress">In Progress</h3>
           <ul>
-            <li>Network+ study</li>
+            <li>CompTIA A+ study</li>
             <li>Home lab documentation</li>
             <li>Ticket-style troubleshooting notes</li>
-            <li>Security+ foundation after Network+</li>
+            <li>Help desk workflow practice</li>
           </ul>
         </section>
 
@@ -74,7 +76,7 @@
 
   <section class="section" id="readiness"><div class="container"><h2>Help Desk Readiness</h2><div class="tile-grid"><article class="tile">Windows 10/11 troubleshooting</article><article class="tile">Basic networking support</article><article class="tile">DNS, DHCP, and Wi-Fi basics</article><article class="tile">User account and password support</article><article class="tile">Remote support basics</article><article class="tile">Printer and peripheral support</article><article class="tile">Software installs and updates</article><article class="tile">Ticket notes and documentation</article><article class="tile">Customer-facing communication</article><article class="tile">Methodical problem solving</article></div></div></section>
 
-  <section class="section" id="about"><div class="container narrow"><h2>About</h2><p>I am an IT support candidate and cybersecurity student based in Palm Bay, Florida. My background includes hands-on troubleshooting labs, home networking, front-end development projects, and practical technical documentation.</p><p>I value clear communication, patient support, organized notes, and reliable follow-through when working through technical problems.</p></div></section>
+  <section class="section" id="about"><div class="container narrow"><h2>About</h2><p>I am an IT support candidate and cybersecurity student based in Palm Bay, Florida. I am currently preparing for CompTIA A+ as I build toward an entry-level help desk or IT support role.</p><p>I value clear communication, patient support, organized notes, and reliable follow-through when working through technical problems.</p></div></section>
 
   <section class="section" id="skills"><div class="container"><h2>Skills</h2><div class="card-grid"><article class="card"><h3>Help Desk &amp; User Support</h3><p>Windows 10/11 support, password reset support, printer troubleshooting, remote support basics, ticket documentation, user account support, software install/update support.</p></article><article class="card"><h3>Networking Fundamentals</h3><p>TCP/IP, DNS, DHCP, Wi-Fi troubleshooting, Ethernet troubleshooting, basic routing and switching, VLAN concepts, device inventory.</p></article><article class="card"><h3>Cybersecurity Foundations</h3><p>CIA triad, least privilege, MFA, patch management, account security, logging basics, security awareness.</p></article><article class="card"><h3>Tools &amp; Platforms</h3><p>Windows, macOS, Linux CLI basics, Git/GitHub, VS Code, Wireshark, Nmap/Zenmap, Microsoft 365, Google Workspace, Docker basics.</p></article><article class="card"><h3>Customer Service &amp; Communication</h3><p>Clear documentation, calm issue handling, customer service, team collaboration, follow-through, explaining technical issues clearly, problem solving under pressure.</p></article></div></div></section>
 
@@ -82,7 +84,7 @@
 
   <section class="section" id="projects"><div class="container"><h2>Projects &amp; Labs</h2><p class="section-intro">Selected labs and projects showing practical troubleshooting, networking, documentation, and self-hosted systems experience.</p><div class="card-grid two"><article class="card"><h3>Home Network Lab</h3><p>Built and maintained a home network with managed hardware, Wi-Fi access points, NAS storage, and client devices. Practiced DNS/DHCP troubleshooting, connectivity testing, device inventory, and basic segmentation planning.</p><p><strong>Support relevance:</strong> Matches common support work involving Wi-Fi issues, device connectivity, and network documentation.</p><p class="tags">Networking, DNS, DHCP, Wi-Fi, Documentation</p></article><article class="card"><h3>Help Desk Troubleshooting Labs</h3><p>Ran troubleshooting labs covering Windows 10/11 settings, Event Viewer, user accounts, remote desktop setup, system recovery, updates, printers, and network connectivity.</p><p><strong>Support relevance:</strong> Directly maps to common entry-level help desk tickets.</p><p class="tags">Windows, Troubleshooting, Event Viewer, Remote Desktop, Support</p></article><article class="card"><h3>NAS &amp; Backup Workflow</h3><p>Implemented a NAS and external-drive backup workflow with structured folders, retention habits, and access control basics.</p><p><strong>Support relevance:</strong> Shows awareness of data organization, backup habits, and access control.</p><p class="tags">NAS, Backups, Storage, Access Control, Documentation</p></article><article class="card"><h3>Raspberry Pi &amp; Docker Experiments</h3><p>Deployed small self-hosted services on Raspberry Pi and Docker while practicing Linux CLI, configuration changes, logging, and service recovery.</p><p><strong>Support relevance:</strong> Shows initiative outside classwork and steady hands-on troubleshooting practice.</p><p class="tags">Linux, Docker, Raspberry Pi, Logs, Self-Hosting</p></article><article class="card"><h3>React Baby Tracker App</h3><p>Built a React tracking app to practice component structure, state management, form handling, and clean interface behavior.</p><p><strong>Support relevance:</strong> Shows problem-solving, organization, and the ability to build practical tools.</p><p class="tags">React, JavaScript, Forms, State Management, UI</p><a class="inline-link" href="https://github.com/wilkins4" target="_blank" rel="noopener noreferrer">View related code on GitHub</a></article></div></div></section>
 
-  <section class="section" id="education-certifications"><div class="container card-grid two"><article class="card"><h2>Education</h2><h3>Eastern Florida State College</h3><p class="meta">Cybersecurity, In Progress</p><p>Studying networking, security foundations, operating systems, troubleshooting, and cybersecurity concepts.</p><h3>Canisius College</h3><p class="meta">BS Digital Media Arts, 2016</p><p>Built a foundation in technical communication, digital tools, design thinking, and project-based work.</p></article><article class="card"><h2>Certifications</h2><ul class="cert-list"><li><strong>CompTIA A+</strong> — <span>Earned</span><p>Covers hardware, software, networking, troubleshooting, operating systems, mobile devices, and support fundamentals.</p></li><li><strong>CompTIA Network+</strong> — <span>In Progress</span><p>Current certification focus covering networking concepts, infrastructure, operations, troubleshooting, and security fundamentals.</p></li><li><strong>CompTIA Security+</strong> — <span>Planned</span><p>Planned next step after Network+, focused on security operations, threats, risk, governance, and compliance.</p></li></ul></article></div></section>
+  <section class="section" id="education-certifications"><div class="container card-grid two"><article class="card"><h2>Education</h2><h3>Eastern Florida State College</h3><p class="meta">Cybersecurity, In Progress</p><p>Studying networking, security foundations, operating systems, troubleshooting, and cybersecurity concepts.</p><h3>Canisius College</h3><p class="meta">BS Digital Media Arts, 2016</p><p>Built a foundation in technical communication, digital tools, design thinking, and project-based work.</p></article><article class="card"><h2>Certification Goals</h2><ul class="cert-list"><li><strong>CompTIA A+ - In Progress</strong><p>Current focus covering hardware, software, networking basics, troubleshooting, operating systems, mobile devices, and support fundamentals.</p></li></ul></article></div></section>
 
   <section class="section" id="contact"><div class="container contact"><h2>Contact</h2><p>I am available for entry-level help desk, desktop support, and IT support roles. Open to remote opportunities and roles in the Palm Bay / Melbourne, FL area.</p><div class="cta-row"><a class="button primary" href="mailto:scwilkinson36@gmail.com">Email Me</a><a class="button accent" href="resume.html" download>Download Resume</a><a class="button ghost" href="https://github.com/wilkins4" target="_blank" rel="noopener noreferrer">GitHub</a><a class="button ghost" href="https://www.linkedin.com/in/stephen-wilkinson" target="_blank" rel="noopener noreferrer">LinkedIn</a></div></div></section>
 </main>

--- a/styles.css
+++ b/styles.css
@@ -18,7 +18,7 @@ a{color:var(--brand)}a:focus-visible,button:focus-visible{outline:3px solid var(
 .snapshot-section ul{margin:0;padding-left:1rem;display:grid;gap:.15rem}
 .snapshot-section li{line-height:1.35;color:#dce8ff}
 h1{font-size:clamp(2rem,3.2vw,3.2rem);line-height:1.15;margin:.25rem 0 .4rem}h2{font-size:clamp(1.5rem,2.2vw,2rem);margin:0 0 .8rem}
-.badge-row{display:flex;flex-wrap:wrap;gap:.5rem;margin:1rem 0}.badge{padding:.33rem .7rem;border-radius:999px;font-size:.82rem;font-weight:600}.earned{background:#193927;color:#9af3bc}.progress{background:#29375d;color:#b7d4ff}.planned{background:#3b2e1f;color:#ffd49d}.neutral{background:#22314d;color:#dce9ff}
+.badge-row{display:flex;flex-wrap:wrap;gap:.5rem;margin:1rem 0}.badge{padding:.33rem .7rem;border-radius:999px;font-size:.82rem;font-weight:600}.progress{background:#29375d;color:#b7d4ff}.planned{background:#3b2e1f;color:#ffd49d}.neutral{background:#22314d;color:#dce9ff}
 .cta-row{display:flex;flex-wrap:wrap;gap:.65rem;margin-top:1rem}.button{padding:.72rem 1rem;border-radius:10px;text-decoration:none;font-weight:600;border:1px solid transparent}.primary{background:var(--brand);color:#071427}.accent{background:var(--brand-2);color:#062116}.ghost{background:transparent;border-color:var(--line);color:var(--text)}
 .tile-grid{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:.7rem}.tile{padding:.8rem .9rem;font-weight:500}
 .card-grid{display:grid;gap:1rem;grid-template-columns:1fr}.card{padding:1rem 1.1rem}.two{grid-template-columns:repeat(2,minmax(0,1fr))}


### PR DESCRIPTION
### Motivation
- Reflect the current certification progress by changing CompTIA A+ from "Completed" to "In Progress" and streamline messaging for entry-level roles. 
- Improve the hero and education wording to present a concise candidate headline and clearer certification goals. 
- Remove earned badge styling to avoid implying completed certifications that are still in progress.

### Description
- Updated `index.html` to change the page `<title>`, `meta` description, and `og:description` to reflect `CompTIA A+` as in progress and to use a concise hero headline (`Entry-Level IT Support Candidate`) and meta line for the name/location. 
- Revised hero content and badges in `index.html` to show `CompTIA A+ In Progress`, simplified the badge set, added a `section-intro` line in the hero, and adjusted snapshot/in-progress items and `About` copy to match the new certification status. 
- Reworked the certifications section in `index.html` to replace the previous multi-cert list with a single `Certification Goals` card that documents `CompTIA A+ - In Progress`. 
- Updated `styles.css` to remove the `.earned` badge style and keep badge styling consistent with the new badge set and layout.

### Testing
- No automated tests were run for this content and stylesheet update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b2b71c2c8320bb970b25744185e6)