### PR TITLE
Revise downloadable resume for entry-level IT support focus

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -7,43 +7,86 @@
 </head>
 <body>
   <h1>Stephen Wilkinson</h1>
-  <h2>Networking Skills</h2>
-  <p>Added from competency certificate in networking.</p>
+  <p>Palm Bay, FL · Open to Remote, Hybrid, and On-Site Roles</p>
+  <p>Email: scwilkinson36@gmail.com</p>
 
-  <h3>Network Hardware</h3>
+  <h2>Professional Summary</h2>
+  <p>
+    Entry-level IT support candidate and cybersecurity student preparing for CompTIA A+.
+    Hands-on experience with Windows troubleshooting, basic networking support, user account issues,
+    and home lab documentation. Known for clear communication, steady follow-through,
+    and customer-focused problem solving.
+  </p>
+
+  <h2>Core Skills</h2>
   <ul>
-    <li>Implement components and cabling solutions</li>
-    <li>Implement wired and wireless devices</li>
+    <li>Windows 10/11 troubleshooting</li>
+    <li>User account and password support</li>
+    <li>Software installation and updates</li>
+    <li>Printer and peripheral troubleshooting</li>
+    <li>Networking basics: TCP/IP, DNS, DHCP, Wi-Fi</li>
+    <li>Ticket-style notes and issue documentation</li>
+    <li>Customer service and issue de-escalation</li>
+    <li>Basic security practices: MFA, least privilege, patching</li>
   </ul>
 
-  <h3>Network Configuration</h3>
+  <h2>Technical Projects &amp; Labs</h2>
+
+  <h3>Home Network Lab</h3>
   <ul>
-    <li>Configure IP addressing</li>
-    <li>Configure routers and switches</li>
-    <li>Configure wireless and VoIP</li>
+    <li>Built and maintained a home network with managed hardware, Wi-Fi access points, and client devices.</li>
+    <li>Troubleshot DNS and DHCP issues, connectivity drops, and device conflicts.</li>
+    <li>Maintained basic device inventory and troubleshooting notes.</li>
   </ul>
 
-  <h3>Network Management</h3>
+  <h3>Help Desk Troubleshooting Practice</h3>
   <ul>
-    <li>Manage DHCP services</li>
-    <li>Manage DNS services</li>
-    <li>Manage device discovery and VLANs</li>
-    <li>Manage logs</li>
+    <li>Practiced common support scenarios in Windows 10/11: updates, account issues, remote desktop, and printer setup.</li>
+    <li>Used Event Viewer and system tools to isolate and resolve recurring errors.</li>
+    <li>Documented symptoms, steps taken, and outcomes in ticket-style format.</li>
   </ul>
 
-  <h3>Network Security</h3>
+  <h3>NAS &amp; Backup Workflow</h3>
   <ul>
-    <li>Secure firewalls and security appliances</li>
-    <li>Secure switches and wireless networks</li>
-    <li>Secure services and passwords</li>
-    <li>Secure remote connections and VPNs</li>
-    <li>Secure network exploits</li>
+    <li>Set up a personal NAS and external backup routine with organized folder structure.</li>
+    <li>Applied basic access controls and retention habits to improve data reliability.</li>
   </ul>
 
-  <h3>Network Troubleshooting</h3>
+  <h3>Raspberry Pi and Docker Labs</h3>
   <ul>
-    <li>Troubleshoot configuration and services</li>
-    <li>Troubleshoot wired and wireless connectivity</li>
+    <li>Ran lightweight self-hosted services to practice Linux CLI, logs, and service recovery.</li>
+    <li>Improved troubleshooting habits through repeatable test-and-fix workflows.</li>
+  </ul>
+
+  <h2>Experience</h2>
+
+  <h3>Front-End Freelance Developer</h3>
+  <p>August 2023 to Present</p>
+  <ul>
+    <li>Built and maintained small websites while resolving layout, compatibility, and usability issues.</li>
+    <li>Communicated with users to clarify problems, set expectations, and deliver practical fixes.</li>
+    <li>Strengthened documentation, troubleshooting, and iterative support habits.</li>
+  </ul>
+
+  <h3>Cook and Cashier, Samson's Concessions</h3>
+  <p>September 2020 to April 2023</p>
+  <ul>
+    <li>Delivered customer-facing service in a fast-paced environment with accuracy and professionalism.</li>
+    <li>Handled high-volume requests while maintaining composure and clear communication.</li>
+    <li>Built reliability, teamwork, and accountability under pressure.</li>
+  </ul>
+
+  <h2>Education</h2>
+
+  <h3>Eastern Florida State College</h3>
+  <p>Cybersecurity, In Progress</p>
+
+  <h3>Canisius College</h3>
+  <p>BS Digital Media Arts, 2016</p>
+
+  <h2>Certifications</h2>
+  <ul>
+    <li>CompTIA A+ (In Progress)</li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Align the downloadable resume with hireable, junior IT support roles by emphasizing CompTIA A+ progress, practical troubleshooting, home lab experience, and customer-service reliability. 
- Remove non-essential developer signals (like GitHub links) and reduce senior/oversell language to present a dependable entry-level candidate.

### Description
- Rewrote `resume.html` to a clean resume structure with `Professional Summary`, `Core Skills`, `Technical Projects & Labs`, `Experience`, `Education`, and `Certifications` sections. 
- Shifted content to highlight Windows troubleshooting, user/account support, networking basics (DNS/DHCP/Wi‑Fi), ticket-style documentation, and hands-on home-lab projects. 
- Removed prior networking-competency list and GitHub references and added a minimal contact line (`Palm Bay, FL` and email) suitable for PDF export and tailoring.

### Testing
- Validated the updated file contents by inspecting `resume.html` (viewed with `nl -ba resume.html`) to confirm structure and copy updates. 
- Ensured the HTML is well-formed and self-contained for export to PDF or inclusion in the site. 
- No automated test suite was run and no test failures were observed during local inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b696add08320bff89d12ac071785)